### PR TITLE
Added enable_dns_support and enable_dns_hostnames to VPC creation

### DIFF
--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -8,6 +8,8 @@
 
 resource "aws_vpc" "demo" {
   cidr_block = "10.0.0.0/16"
+  enable_dns_support = true
+  enable_dns_hostnames = true
 
   tags = "${
     map(


### PR DESCRIPTION
Added enable_dns_support and enable_dns_hostnames to VPC creation in order to support private DNS in an EKS VPC