### PR TITLE
Changed the EKS AMI filter

### DIFF
--- a/terraform/eks-worker-nodes.tf
+++ b/terraform/eks-worker-nodes.tf
@@ -89,7 +89,7 @@ resource "aws_security_group_rule" "demo-node-ingress-cluster" {
 data "aws_ami" "eks-worker" {
   filter {
     name   = "name"
-    values = ["eks-worker-*"]
+    values = ["amazon-eks-node-v*"]
   }
 
   most_recent = true


### PR DESCRIPTION
Using the AMI you suggested resulted in an error of Criteria Search on Terraform. This was due to the missmatch AMI's. Following the official Terraform Starting Guide (https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html) I changed the value of the AWS_AMI resource on the EKS-Worker Terraform Resource.

```tf
data "aws_ami" "eks-worker" {
  filter {
    name   = "name"
    values = ["amazon-eks-node-v*"]
  }

  most_recent = true
  owners      = ["602401143452"] # Amazon
}
```
